### PR TITLE
feat: add landing page, docs site, and donation links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Funding links shown on the repo "Sponsor" button.
+github: [sgiraz]
+ko_fi: sgiraz

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 [![Vue](https://img.shields.io/badge/Vue-3.x-4FC08D?logo=vue.js)](https://vuejs.org/)
 [![Docker](https://img.shields.io/badge/Docker-ready-2496ED?logo=docker)](https://hub.docker.com/u/sgira)
 
+### 🌐 [Live Demo](https://demo.homelog.dev) &nbsp;·&nbsp; 🏠 [Website](https://homelog.dev) &nbsp;·&nbsp; 📖 [Documentation](https://docs.homelog.dev)
+
+> Try the **[live demo](https://demo.homelog.dev)** with sample data (resets hourly) — then self-host your own private instance with the [Quick Start](#quick-start) below.
+
 ## Screenshots
 
 <table>
@@ -151,11 +155,11 @@ Contributions are welcome! Here's how:
 
 If HomeLog is useful to you, consider supporting its development:
 
-- Star this repository
+- ⭐ Star this repository
+- ❤️ Donate via [Ko-fi](https://ko-fi.com/sgiraz) or [GitHub Sponsors](https://github.com/sponsors/sgiraz)
 - [Report bugs or suggest features](https://github.com/sgiraz/homelog/issues)
 - [Join the discussion](https://github.com/sgiraz/homelog/discussions)
 - Contribute code, translations, or documentation
-<!-- - [Sponsor on GitHub](https://github.com/sponsors/sgiraz) -->
 
 ---
 

--- a/docs-site/.gitignore
+++ b/docs-site/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.vitepress/dist/
+.vitepress/cache/

--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -1,0 +1,121 @@
+import { defineConfig } from 'vitepress'
+
+// HomeLog user documentation — docs.homelog.dev.
+// Served from a custom subdomain, so the site lives at the root (base: '/').
+// Bilingual: English at /, Italian at /it/.
+export default defineConfig({
+  title: 'HomeLog Docs',
+  description: 'How to use HomeLog — self-hosted home expense & utilities manager for families.',
+  lastUpdated: true,
+  // Local install URLs aren't reachable at build time — don't fail on them.
+  ignoreDeadLinks: [/^https?:\/\/localhost/],
+  head: [
+    ['link', { rel: 'icon', href: '/favicon.svg', type: 'image/svg+xml' }],
+    ['meta', { name: 'theme-color', content: '#D9531E' }],
+    // First-visit default to the browser language: only on the English home,
+    // once per session (so manually switching back to English doesn't loop).
+    ['script', {}, `try{
+      var p = location.pathname;
+      if ((p === '/' || p === '/index.html') &&
+          !sessionStorage.getItem('hl-lang-redirect') &&
+          (navigator.language || '').toLowerCase().indexOf('it') === 0) {
+        sessionStorage.setItem('hl-lang-redirect', '1');
+        location.replace('/it/');
+      }
+    }catch(e){}`],
+  ],
+  themeConfig: {
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/sgiraz/homelog' },
+    ],
+    search: { provider: 'local' },
+  },
+  locales: {
+    root: {
+      label: 'English',
+      lang: 'en-US',
+      themeConfig: {
+        nav: [
+          { text: 'Guide', link: '/guide/getting-started', activeMatch: '/guide/' },
+          { text: 'Live Demo', link: 'https://demo.homelog.dev' },
+          { text: 'Website', link: 'https://homelog.dev' },
+        ],
+        sidebar: {
+          '/guide/': [
+            {
+              text: 'Getting Started',
+              items: [
+                { text: 'Introduction', link: '/guide/getting-started' },
+                { text: 'Self-Hosting', link: '/guide/self-hosting' },
+              ],
+            },
+            {
+              text: 'Using HomeLog',
+              items: [
+                { text: 'Expenses & Splitting', link: '/guide/expenses' },
+                { text: 'Utilities & Bills', link: '/guide/utilities' },
+                { text: 'PDF Bill Templates', link: '/guide/pdf-templates' },
+                { text: 'Projects', link: '/guide/projects' },
+              ],
+            },
+          ],
+        },
+        editLink: {
+          pattern: 'https://github.com/sgiraz/homelog/edit/main/docs-site/:path',
+          text: 'Edit this page on GitHub',
+        },
+        footer: {
+          message: '🚧 Work in progress · Released under the AGPL-3.0 License.',
+          copyright: 'HomeLog — self-hosted home management.',
+        },
+      },
+    },
+    it: {
+      label: 'Italiano',
+      lang: 'it-IT',
+      link: '/it/',
+      themeConfig: {
+        nav: [
+          { text: 'Guida', link: '/it/guide/getting-started', activeMatch: '/it/guide/' },
+          { text: 'Demo live', link: 'https://demo.homelog.dev' },
+          { text: 'Sito', link: 'https://homelog.dev' },
+        ],
+        sidebar: {
+          '/it/guide/': [
+            {
+              text: 'Per iniziare',
+              items: [
+                { text: 'Introduzione', link: '/it/guide/getting-started' },
+                { text: 'Self-hosting', link: '/it/guide/self-hosting' },
+              ],
+            },
+            {
+              text: 'Usare HomeLog',
+              items: [
+                { text: 'Spese e divisione', link: '/it/guide/expenses' },
+                { text: 'Utenze e bollette', link: '/it/guide/utilities' },
+                { text: 'Template PDF', link: '/it/guide/pdf-templates' },
+                { text: 'Progetti', link: '/it/guide/projects' },
+              ],
+            },
+          ],
+        },
+        editLink: {
+          pattern: 'https://github.com/sgiraz/homelog/edit/main/docs-site/:path',
+          text: 'Modifica questa pagina su GitHub',
+        },
+        footer: {
+          message: '🚧 Lavori in corso · Rilasciato sotto licenza AGPL-3.0.',
+          copyright: 'HomeLog — gestione domestica self-hosted.',
+        },
+        docFooter: { prev: 'Precedente', next: 'Successivo' },
+        outline: { label: 'In questa pagina' },
+        lastUpdated: { text: 'Ultimo aggiornamento' },
+        langMenuLabel: 'Cambia lingua',
+        returnToTopLabel: 'Torna su',
+        sidebarMenuLabel: 'Menu',
+        darkModeSwitchLabel: 'Tema',
+      },
+    },
+  },
+})

--- a/docs-site/.vitepress/theme/Layout.vue
+++ b/docs-site/.vitepress/theme/Layout.vue
@@ -1,0 +1,45 @@
+<script setup>
+import DefaultTheme from 'vitepress/theme'
+import { useData } from 'vitepress'
+import { computed } from 'vue'
+
+const { Layout } = DefaultTheme
+const { lang } = useData()
+const isIt = computed(() => (lang.value || '').toLowerCase().startsWith('it'))
+</script>
+
+<template>
+  <Layout>
+    <template #layout-top>
+      <div class="wip-banner">
+        <template v-if="isIt">
+          🚧 <strong>Lavori in corso</strong> — questa documentazione è ancora in fase di scrittura.
+          <a href="https://github.com/sgiraz/homelog" target="_blank" rel="noopener">Contribuisci su GitHub →</a>
+        </template>
+        <template v-else>
+          🚧 <strong>Work in progress</strong> — these docs are still being written.
+          <a href="https://github.com/sgiraz/homelog" target="_blank" rel="noopener">Help out on GitHub →</a>
+        </template>
+      </div>
+    </template>
+  </Layout>
+</template>
+
+<style scoped>
+.wip-banner {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  text-align: center;
+  font-size: 13px;
+  padding: 6px 16px;
+  color: #fff;
+  background: linear-gradient(90deg, #D9531E, #B23F12);
+}
+.wip-banner a {
+  color: #fff;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+</style>

--- a/docs-site/.vitepress/theme/custom.css
+++ b/docs-site/.vitepress/theme/custom.css
@@ -1,0 +1,15 @@
+/* HomeLog docs — warm "ember" accent to match homelog.dev. */
+:root {
+  --vp-c-brand-1: #B23F12;
+  --vp-c-brand-2: #D9531E;
+  --vp-c-brand-3: #D9531E;
+  --vp-c-brand-soft: rgba(217, 83, 30, 0.14);
+
+  --vp-home-hero-name-color: #D9531E;
+}
+
+.dark {
+  --vp-c-brand-1: #E2783F;
+  --vp-c-brand-2: #D9531E;
+  --vp-c-brand-3: #B23F12;
+}

--- a/docs-site/.vitepress/theme/index.js
+++ b/docs-site/.vitepress/theme/index.js
@@ -1,0 +1,9 @@
+import DefaultTheme from 'vitepress/theme'
+import Layout from './Layout.vue'
+import './custom.css'
+
+// Extend the default theme with a persistent "work in progress" banner.
+export default {
+  extends: DefaultTheme,
+  Layout,
+}

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -1,0 +1,31 @@
+# Documentation — docs.homelog.dev
+
+User documentation for HomeLog, built with [VitePress](https://vitepress.dev).
+**Work in progress** (a persistent banner says so on every page).
+
+## Local development
+
+```bash
+cd docs-site
+npm install
+npm run docs:dev      # local preview with hot reload
+npm run docs:build    # production build → .vitepress/dist
+```
+
+## Deploy on Render (static site)
+
+1. New → **Static Site** → connect the repo.
+2. **Root Directory:** `docs-site`
+3. **Build Command:** `npm install && npm run docs:build`
+4. **Publish Directory:** `.vitepress/dist`
+5. Add custom domain **docs.homelog.dev**.
+
+Because the site is served from a custom subdomain, `base` stays `/` — the same
+build works on GitHub Pages, Cloudflare Pages or Netlify.
+
+## Structure
+
+- `index.md` — home page (hero + feature cards).
+- `guide/*.md` — the documentation pages.
+- `.vitepress/config.mjs` — nav, sidebar, theme config.
+- `.vitepress/theme/` — ember accent + the work-in-progress banner.

--- a/docs-site/guide/expenses.md
+++ b/docs-site/guide/expenses.md
@@ -1,0 +1,34 @@
+# Expenses & Splitting
+
+::: warning Work in progress
+This page is a stub. Screenshots and step-by-step walkthroughs are coming.
+:::
+
+Expenses are the heart of HomeLog. Each expense records what was spent, who paid,
+and — optionally — how it's shared with the rest of the household.
+
+## Recording an expense
+
+From the **Expenses** tab, add an expense with an amount, date, category, and the
+member who paid. Categories and subcategories are configurable in **Settings →
+Categories**.
+
+## Splitting
+
+When an expense is shared, HomeLog creates a **split** for each participating
+member. The split records how much each person owes. The payer never owes
+themselves, so their own share is marked as settled automatically.
+
+Household-wide defaults (split equally, by share, or not at all) can be set once,
+and individual expenses can override them.
+
+## Balances & settling up
+
+The **Balance** tab shows who owes whom across all unsettled splits. Recording a
+settlement marks the relevant splits as paid, keeping the running balance
+accurate.
+
+## Templates
+
+Frequent expenses (weekly groceries, rent…) can be saved as **templates** so you
+can add them in one tap. Manage them in **Settings → Preferences**.

--- a/docs-site/guide/getting-started.md
+++ b/docs-site/guide/getting-started.md
@@ -1,0 +1,41 @@
+# Introduction
+
+::: warning Work in progress
+This guide is being written. Content is incomplete and may change.
+:::
+
+**HomeLog** is a self-hosted, multi-user manager for the money that keeps a home
+running. It combines three things most apps keep separate:
+
+- **Shared expenses** — split costs between household members and settle up.
+- **Utilities** — log meter readings and store provider bills for electricity, gas and water.
+- **Analysis** — see billed vs. actual consumption and where your money goes.
+
+Everything runs in a single Docker container on hardware you control — from a VPS
+to a Raspberry Pi 3B+.
+
+## Try before you install
+
+The fastest way to see what HomeLog does is the **[live demo](https://demo.homelog.dev)**.
+It comes pre-loaded with sample data (which resets every hour), so you can click
+around freely without signing up.
+
+When you're ready to use it for real, follow the [Self-Hosting](./self-hosting)
+guide to deploy your own private instance.
+
+## Core concepts
+
+| Concept | What it is |
+| --- | --- |
+| **Property** | A home/household. Expenses, utilities and members belong to a property. |
+| **Member** | A person who shares expenses. Balances are tracked per member. |
+| **Expense** | A cost, optionally split between members and settled over time. |
+| **Utility** | A service (electricity, gas, water…) with readings and bills. |
+| **Bill** | A provider invoice, optionally linked to a meter reading. |
+| **Project** | A budget for a one-off effort — a renovation, a trip, an event. |
+
+## Where to next
+
+- [Self-Hosting →](./self-hosting) — get your own instance running.
+- [Expenses & Splitting →](./expenses) — the day-to-day basics.
+- [Utilities & Bills →](./utilities) — readings, bills and consumption.

--- a/docs-site/guide/pdf-templates.md
+++ b/docs-site/guide/pdf-templates.md
@@ -1,0 +1,32 @@
+# PDF Bill Templates
+
+::: warning Work in progress
+This page is a stub. A full walkthrough with screenshots is coming.
+:::
+
+Provider bills are PDFs, and typing their figures by hand is tedious. HomeLog's
+**template wizard** lets you teach the app to read a given provider's layout
+**once** — after that, uploading a bill auto-fills the amount, period, meter
+reading, and more.
+
+## How it works
+
+1. **Upload a sample bill.** HomeLog converts the PDF to text and detects tokens
+   like amounts, dates, meter codes (POD/PDR), and numbers.
+2. **Tag the fields.** In a 3-step wizard, point at the value you want for each
+   field (total amount, period, provider reading…). HomeLog records where it sits
+   on the page and how to recognise it.
+3. **Save the template.** Assign it as the default for a service, and future bills
+   from the same provider are parsed automatically.
+
+## Extraction strategy
+
+To stay accurate even when a label appears more than once on a page, HomeLog
+tries several strategies in order: unique global IDs first, then anchor/label
+position, then the spot you originally tagged, then a pattern match with
+surrounding context.
+
+::: tip
+Extraction patterns are restricted to a regex flavour without look-ahead /
+look-behind, which keeps parsing fast and predictable on low-powered hardware.
+:::

--- a/docs-site/guide/projects.md
+++ b/docs-site/guide/projects.md
@@ -1,0 +1,20 @@
+# Projects
+
+::: warning Work in progress
+This page is a stub. Screenshots and step-by-step walkthroughs are coming.
+:::
+
+**Projects** are budgets for one-off efforts that don't fit the monthly rhythm of
+regular expenses — a kitchen renovation, a summer trip, a birthday party.
+
+## What a project tracks
+
+- A **budget** target.
+- The **expenses** assigned to it, so you can watch spend against the budget.
+- Progress at a glance, so you know how much room is left.
+
+## Working with projects
+
+Create a project from the **Projects** tab, give it a budget, then assign
+expenses to it as you record them. The project view rolls everything up into a
+single total and remaining balance.

--- a/docs-site/guide/self-hosting.md
+++ b/docs-site/guide/self-hosting.md
@@ -1,0 +1,54 @@
+# Self-Hosting
+
+::: warning Work in progress
+This guide is being written. For the full, up-to-date deployment reference see
+the [DEPLOY-GUIDE.md](https://github.com/sgiraz/homelog/blob/main/DEPLOY-GUIDE.md)
+in the repository.
+:::
+
+HomeLog ships as a **single Docker container**: the Go binary serves the API and
+the embedded frontend, backed by SQLite. No separate database or web server to
+run.
+
+## Quick start with Docker
+
+```bash
+git clone https://github.com/sgiraz/homelog.git && cd homelog
+cp .env.example .env
+
+# Set a secure JWT secret (the only required setting):
+#   Linux/macOS:  openssl rand -base64 32
+# Paste the output into .env as JWT_SECRET=...
+
+docker compose up -d
+```
+
+Then open **http://localhost:8080**, register the first account, and start
+tracking.
+
+## Using the pre-built image
+
+```bash
+mkdir homelog && cd homelog
+echo "JWT_SECRET=$(openssl rand -base64 32)" > .env
+curl -O https://raw.githubusercontent.com/sgiraz/homelog/main/docker-compose.yml
+docker compose up -d
+```
+
+Multi-arch images (amd64 / arm64 / arm/v7) are published on
+[Docker Hub](https://hub.docker.com/u/sgira), so the same compose file works on a
+Raspberry Pi.
+
+## Configuration
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `JWT_SECRET` | _(required)_ | Secret used to sign auth tokens. |
+| `DB_PATH` | `./data/homelog.db` | SQLite database location. |
+| `GIN_MODE` | `debug` | Set to `release` in production. |
+
+## Going further
+
+The repository's
+[DEPLOY-GUIDE.md](https://github.com/sgiraz/homelog/blob/main/DEPLOY-GUIDE.md)
+covers Raspberry Pi setup, remote access with Tailscale, backups, and hardening.

--- a/docs-site/guide/utilities.md
+++ b/docs-site/guide/utilities.md
@@ -1,0 +1,43 @@
+# Utilities & Bills
+
+::: warning Work in progress
+This page is a stub. Screenshots and step-by-step walkthroughs are coming.
+:::
+
+A **utility** is a service tied to your home — electricity, gas, water, and so
+on. Each utility keeps its own meter readings, bills, and consumption history.
+
+## Meter readings
+
+Log readings over time from the utility's **Readings** tab. HomeLog supports:
+
+- single-value meters (gas, water),
+- multi-band electricity meters (F1 / F2 / F3),
+- estimated readings, when a bill is based on an estimate rather than a real one.
+
+## Bills
+
+Store each provider invoice under **Bills** — amount, period, due date, and the
+provider's meter reading. A bill can be **linked to one of your readings**, which
+is what powers the consumption analysis.
+
+When you mark a bill as **paid**, HomeLog can automatically create the matching
+expense (and split it), using the payer configured for that service.
+
+## Consumption analysis
+
+The **Analysis** tab compares **billed** consumption against **actual**
+consumption between consecutive bills, so you can spot estimate errors or
+unexpected spikes.
+
+## Domiciliation & instalments
+
+Two independent flags describe how a service is paid:
+
+- **Domiciled** — paid automatically by direct debit.
+- **Instalment-based** — billed in instalments.
+
+A service can be either, both, or neither.
+
+See [PDF Bill Templates](./pdf-templates) to automate reading figures straight
+from your provider's PDFs.

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -1,0 +1,41 @@
+---
+layout: home
+
+hero:
+  name: HomeLog
+  text: Documentation
+  tagline: How to track your household's expenses, utilities and bills — and host it all yourself.
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /guide/getting-started
+    - theme: alt
+      text: Live Demo
+      link: https://demo.homelog.dev
+    - theme: alt
+      text: GitHub
+      link: https://github.com/sgiraz/homelog
+
+features:
+  - icon: 🤝
+    title: Expenses & Splitting
+    details: Record shared expenses, split them between members, and settle balances.
+    link: /guide/expenses
+  - icon: ⚡
+    title: Utilities & Bills
+    details: Meter readings, provider bills, and consumption analysis for electricity, gas and water.
+    link: /guide/utilities
+  - icon: 📄
+    title: PDF Bill Templates
+    details: Teach HomeLog to read your bills once, then auto-extract every figure.
+    link: /guide/pdf-templates
+  - icon: 🚀
+    title: Self-Hosting
+    details: Deploy your own private instance with Docker — even on a Raspberry Pi.
+    link: /guide/self-hosting
+---
+
+::: warning Work in progress
+These docs are just getting started. Pages are incomplete and will change.
+Spotted a gap? [Open an issue or PR on GitHub](https://github.com/sgiraz/homelog/issues).
+:::

--- a/docs-site/it/guide/expenses.md
+++ b/docs-site/it/guide/expenses.md
@@ -1,0 +1,35 @@
+# Spese e divisione
+
+::: warning Lavori in corso
+Questa pagina è una bozza. Screenshot e procedure passo-passo sono in arrivo.
+:::
+
+Le spese sono il cuore di HomeLog. Ogni spesa registra quanto è stato speso, chi
+ha pagato e — facoltativamente — come viene condivisa con il resto della famiglia.
+
+## Registrare una spesa
+
+Dalla scheda **Spese**, aggiungi una spesa con importo, data, categoria e il
+membro che ha pagato. Categorie e sottocategorie si configurano in
+**Impostazioni → Categorie**.
+
+## La divisione
+
+Quando una spesa è condivisa, HomeLog crea una **quota** per ciascun membro
+coinvolto. La quota registra quanto deve ogni persona. Chi paga non deve nulla a
+sé stesso, quindi la sua quota viene segnata come saldata automaticamente.
+
+I valori predefiniti a livello di nucleo (divisione equa, per quote, o nessuna
+divisione) si impostano una volta, e ogni singola spesa può sovrascriverli.
+
+## Saldi e pareggi
+
+La scheda **Bilancio** mostra chi deve cosa a chi su tutte le quote non saldate.
+Registrare un saldo segna come pagate le quote relative, mantenendo il bilancio
+sempre aggiornato.
+
+## Modelli
+
+Le spese ricorrenti (spesa settimanale, affitto…) si possono salvare come
+**modelli** per aggiungerle con un tocco. Si gestiscono in
+**Impostazioni → Preferenze**.

--- a/docs-site/it/guide/getting-started.md
+++ b/docs-site/it/guide/getting-started.md
@@ -1,0 +1,42 @@
+# Introduzione
+
+::: warning Lavori in corso
+Questa guida è in fase di scrittura. I contenuti sono incompleti e potrebbero cambiare.
+:::
+
+**HomeLog** è un gestionale self-hosted e multi-utente per il denaro che fa
+funzionare una casa. Unisce tre cose che la maggior parte delle app tiene
+separate:
+
+- **Spese condivise** — dividi i costi tra i membri della famiglia e salda i conti.
+- **Utenze** — registra le letture dei contatori e archivia le bollette di luce, gas e acqua.
+- **Analisi** — confronta i consumi fatturati con quelli reali e scopri dove vanno i tuoi soldi.
+
+Tutto gira in un unico container Docker, su hardware che controlli tu — da un VPS
+a un Raspberry Pi 3B+.
+
+## Prova prima di installare
+
+Il modo più rapido per vedere cosa fa HomeLog è la **[demo live](https://demo.homelog.dev)**.
+È precaricata con dati di esempio (che si resettano ogni ora), così puoi
+esplorarla liberamente senza registrarti.
+
+Quando sei pronto a usarlo sul serio, segui la guida al
+[Self-hosting](./self-hosting) per installare la tua istanza privata.
+
+## Concetti chiave
+
+| Concetto | Cos'è |
+| --- | --- |
+| **Proprietà** | Una casa/nucleo familiare. Spese, utenze e membri appartengono a una proprietà. |
+| **Membro** | Una persona che condivide le spese. I saldi sono tracciati per membro. |
+| **Spesa** | Un costo, eventualmente diviso tra i membri e saldato nel tempo. |
+| **Utenza** | Un servizio (luce, gas, acqua…) con letture e bollette. |
+| **Bolletta** | Una fattura del fornitore, eventualmente collegata a una lettura del contatore. |
+| **Progetto** | Un budget per un'attività una tantum — una ristrutturazione, un viaggio, un evento. |
+
+## Dove andare ora
+
+- [Self-hosting →](./self-hosting) — metti in piedi la tua istanza.
+- [Spese e divisione →](./expenses) — le basi di tutti i giorni.
+- [Utenze e bollette →](./utilities) — letture, bollette e consumi.

--- a/docs-site/it/guide/pdf-templates.md
+++ b/docs-site/it/guide/pdf-templates.md
@@ -1,0 +1,32 @@
+# Template PDF delle bollette
+
+::: warning Lavori in corso
+Questa pagina è una bozza. Una guida completa con screenshot è in arrivo.
+:::
+
+Le bollette dei fornitori sono PDF, e digitarne i dati a mano è noioso. Il
+**wizard dei template** di HomeLog ti permette di insegnare all'app a leggere il
+layout di un dato fornitore **una volta sola** — dopodiché, caricando una
+bolletta, importo, periodo, lettura del contatore e altro si compilano da soli.
+
+## Come funziona
+
+1. **Carica una bolletta di esempio.** HomeLog converte il PDF in testo e rileva
+   token come importi, date, codici contatore (POD/PDR) e numeri.
+2. **Indica i campi.** In un wizard a 3 step, punta al valore che vuoi per ogni
+   campo (importo totale, periodo, lettura del fornitore…). HomeLog memorizza dove
+   si trova nella pagina e come riconoscerlo.
+3. **Salva il template.** Assegnalo come predefinito per un servizio, e le
+   bollette future dello stesso fornitore vengono analizzate automaticamente.
+
+## Strategia di estrazione
+
+Per restare accurato anche quando un'etichetta compare più volte nella pagina,
+HomeLog prova diverse strategie in ordine: prima gli ID globali univoci, poi la
+posizione dell'etichetta di riferimento, poi il punto che hai indicato in origine,
+infine una corrispondenza per pattern con il contesto circostante.
+
+::: tip
+I pattern di estrazione usano una sintassi regex senza look-ahead / look-behind,
+che mantiene il parsing veloce e prevedibile anche su hardware poco potente.
+:::

--- a/docs-site/it/guide/projects.md
+++ b/docs-site/it/guide/projects.md
@@ -1,0 +1,21 @@
+# Progetti
+
+::: warning Lavori in corso
+Questa pagina è una bozza. Screenshot e procedure passo-passo sono in arrivo.
+:::
+
+I **progetti** sono budget per attività una tantum che non rientrano nel ritmo
+mensile delle spese ordinarie — la ristrutturazione di una cucina, un viaggio
+estivo, una festa di compleanno.
+
+## Cosa traccia un progetto
+
+- Un obiettivo di **budget**.
+- Le **spese** ad esso assegnate, per monitorare la spesa rispetto al budget.
+- L'avanzamento a colpo d'occhio, così sai quanto margine resta.
+
+## Lavorare con i progetti
+
+Crea un progetto dalla scheda **Progetti**, assegnagli un budget, poi associa le
+spese man mano che le registri. La vista del progetto raccoglie tutto in un unico
+totale con il saldo rimanente.

--- a/docs-site/it/guide/self-hosting.md
+++ b/docs-site/it/guide/self-hosting.md
@@ -1,0 +1,54 @@
+# Self-hosting
+
+::: warning Lavori in corso
+Questa guida è in fase di scrittura. Per il riferimento completo e aggiornato sul
+deploy consulta la
+[DEPLOY-GUIDE.md](https://github.com/sgiraz/homelog/blob/main/DEPLOY-GUIDE.md)
+nel repository.
+:::
+
+HomeLog si distribuisce come **un singolo container Docker**: il binario Go serve
+sia l'API sia il frontend incorporato, con SQLite come database. Nessun database
+o web server separato da gestire.
+
+## Avvio rapido con Docker
+
+```bash
+git clone https://github.com/sgiraz/homelog.git && cd homelog
+cp .env.example .env
+
+# Imposta un JWT secret sicuro (l'unica impostazione obbligatoria):
+#   Linux/macOS:  openssl rand -base64 32
+# Incolla il risultato in .env come JWT_SECRET=...
+
+docker compose up -d
+```
+
+Poi apri **http://localhost:8080**, registra il primo account e inizia a tracciare.
+
+## Usare l'immagine pre-buildata
+
+```bash
+mkdir homelog && cd homelog
+echo "JWT_SECRET=$(openssl rand -base64 32)" > .env
+curl -O https://raw.githubusercontent.com/sgiraz/homelog/main/docker-compose.yml
+docker compose up -d
+```
+
+Le immagini multi-arch (amd64 / arm64 / arm/v7) sono pubblicate su
+[Docker Hub](https://hub.docker.com/u/sgira), quindi lo stesso file compose
+funziona anche su un Raspberry Pi.
+
+## Configurazione
+
+| Variabile | Default | Descrizione |
+| --- | --- | --- |
+| `JWT_SECRET` | _(obbligatoria)_ | Segreto usato per firmare i token di autenticazione. |
+| `DB_PATH` | `./data/homelog.db` | Posizione del database SQLite. |
+| `GIN_MODE` | `debug` | Imposta `release` in produzione. |
+
+## Approfondire
+
+La [DEPLOY-GUIDE.md](https://github.com/sgiraz/homelog/blob/main/DEPLOY-GUIDE.md)
+nel repository copre l'installazione su Raspberry Pi, l'accesso remoto con
+Tailscale, i backup e la messa in sicurezza.

--- a/docs-site/it/guide/utilities.md
+++ b/docs-site/it/guide/utilities.md
@@ -1,0 +1,47 @@
+# Utenze e bollette
+
+::: warning Lavori in corso
+Questa pagina è una bozza. Screenshot e procedure passo-passo sono in arrivo.
+:::
+
+Un'**utenza** è un servizio legato alla tua casa — luce, gas, acqua e così via.
+Ogni utenza tiene le proprie letture del contatore, le bollette e lo storico dei
+consumi.
+
+## Letture del contatore
+
+Registra le letture nel tempo dalla scheda **Letture** dell'utenza. HomeLog
+supporta:
+
+- contatori a valore singolo (gas, acqua),
+- contatori elettrici multi-fascia (F1 / F2 / F3),
+- letture stimate, quando una bolletta si basa su una stima invece che su una
+  lettura reale.
+
+## Bollette
+
+Archivia ogni fattura del fornitore in **Bollette** — importo, periodo, scadenza
+e lettura del contatore del fornitore. Una bolletta può essere **collegata a una
+delle tue letture**, ed è ciò che alimenta l'analisi dei consumi.
+
+Quando segni una bolletta come **pagata**, HomeLog può creare automaticamente la
+spesa corrispondente (e dividerla), usando il pagatore configurato per quel
+servizio.
+
+## Analisi dei consumi
+
+La scheda **Analisi** confronta il consumo **fatturato** con quello **effettivo**
+tra bollette consecutive, così puoi individuare errori di stima o picchi
+inattesi.
+
+## Domiciliazione e rate
+
+Due flag indipendenti descrivono come viene pagato un servizio:
+
+- **Domiciliato** — pagato automaticamente con addebito diretto.
+- **Rateizzato** — fatturato a rate.
+
+Un servizio può essere l'uno, l'altro, entrambi o nessuno dei due.
+
+Vedi [Template PDF delle bollette](./pdf-templates) per automatizzare la lettura
+dei dati direttamente dai PDF del tuo fornitore.

--- a/docs-site/it/index.md
+++ b/docs-site/it/index.md
@@ -1,0 +1,41 @@
+---
+layout: home
+
+hero:
+  name: HomeLog
+  text: Documentazione
+  tagline: Come tenere traccia di spese, utenze e bollette di casa — e ospitare tutto sul tuo server.
+  actions:
+    - theme: brand
+      text: Inizia
+      link: /it/guide/getting-started
+    - theme: alt
+      text: Demo live
+      link: https://demo.homelog.dev
+    - theme: alt
+      text: GitHub
+      link: https://github.com/sgiraz/homelog
+
+features:
+  - icon: 🤝
+    title: Spese e divisione
+    details: Registra le spese condivise, dividile tra i membri e salda i conti.
+    link: /it/guide/expenses
+  - icon: ⚡
+    title: Utenze e bollette
+    details: Letture dei contatori, bollette del fornitore e analisi dei consumi per luce, gas e acqua.
+    link: /it/guide/utilities
+  - icon: 📄
+    title: Template PDF delle bollette
+    details: Insegna a HomeLog a leggere le tue bollette una volta sola, poi estrae ogni dato in automatico.
+    link: /it/guide/pdf-templates
+  - icon: 🚀
+    title: Self-hosting
+    details: Installa la tua istanza privata con Docker — anche su un Raspberry Pi.
+    link: /it/guide/self-hosting
+---
+
+::: warning Lavori in corso
+Questa documentazione è appena agli inizi. Le pagine sono incomplete e cambieranno.
+Hai notato qualcosa che manca? [Apri una issue o una PR su GitHub](https://github.com/sgiraz/homelog/issues).
+:::

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -1,0 +1,2513 @@
+{
+  "name": "homelog-docs",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "homelog-docs",
+      "version": "0.1.0",
+      "devDependencies": {
+        "vitepress": "^1.6.3"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.18.1.tgz",
+      "integrity": "sha512-aehCadlWOGvrT91KUIZpC0MbB8KBW9yUuvTJFd2xesR7le/IsT4nJUnjCCZ4ZqZCeTcPHPV5mo//fZ5oxcSVYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.52.1.tgz",
+      "integrity": "sha512-HmXOGBOAOJPounpBzBpuY0zDYeiCpxgHnQmuA7JO6ScukcBdGp3/XM9zJk5pJx/xNGD68mbPGXWpDxGtl6BwDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.52.1.tgz",
+      "integrity": "sha512-5oo4+I8iixie9vXhCyNFCzeIr8pqA3FQ//VsLHTDvZAV4ttYOPGvYHGQq5NSalrLx5Jc3dRro/5uDOlnUMcBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.52.1.tgz",
+      "integrity": "sha512-qCDoZfx5MpX7XQzvQ3bC4tSEMkQWQMaF/ABtLuoze03Y/flR563CCSws02qIJ23oX7lxl92LsilZjINVyTdtLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.52.1.tgz",
+      "integrity": "sha512-hnGs0/lsFJ2PWDxNBz7pxreXo/Xz7gxYRcfePBUjsH26ad0kU/sgnVZd9LwWBpsQv65z2jlb5dkyaB9WE9M9FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.52.1.tgz",
+      "integrity": "sha512-2VxxNc/uBysyKvGeBdSM5n9eIDKH8kWD7wd9/yqbJAiVwU4Yv6tU1LSJusHKrXV/aCu1KW7t9Gug9QyeEmtn/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.52.1.tgz",
+      "integrity": "sha512-O6mPtsw3xEfNOe6gWFpYLeAZAIljNa4Hgna3bq15PwyN7nbjTY0wXJFRbzs/0YVf75Br+SbOQUmjKxXYjDiSiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.52.1.tgz",
+      "integrity": "sha512-gA8oJOV1LnQQkDf91iebNnFInHuW0gRPEgLSOQ7EfipCEjYTHm5swm1DlH9H5RaRw4RrHuzHBegnlzc0MAstcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.52.1.tgz",
+      "integrity": "sha512-U9zZfc5xIu9wRxZkt+HceJUAD4VKHKbAyLSloJdEyMRmphXeibfrY9cxqIXBcmPeZzGhn3Imb35Dq8l19PkJhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.52.1.tgz",
+      "integrity": "sha512-a3SGNceHmkQfq77iG8Ka+w1pvwfZa/0lzEIgse30fL0kD+yKnd/dg0dQvSfFPAEt2f21DMcGkDSSeJlO3KdQjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.52.1.tgz",
+      "integrity": "sha512-z98QEguCFDpxb4S/PyrUK1igqF8tPsdbqOUUO6ON91vJ58w+Gwa6ncrI0oNXSFcrkxA5EqPKPQ2A1PBCn08TYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.52.1.tgz",
+      "integrity": "sha512-CI7+/0I11QeZM59Uc8whd2or0kqzFVjpaPn9Qpwll/krHcBAxk24WkAQ6WX+IwDVMfpont4YGbKwAmCre3vE8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.52.1.tgz",
+      "integrity": "sha512-S6bDuw9byfOvm3T71cgdoZgrgnZq6hpdMLkx52Louh57nUAmvGQESz2aojOynQHjbTiV55smvAFbgn0qT4tJrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.52.1.tgz",
+      "integrity": "sha512-tqZXM+54rWo4mk5jL5Z/flE11nPmNEdXwFBM5py9DkOmbjeCNemfVd45FyM97XdzfZ0dl9uOJC6PYn1FpkeyQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.83",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.83.tgz",
+      "integrity": "sha512-6Pp9V++XisT9RKH7FB4RLPqUDzcmLtSma0ovOEIoEWGrXtHwBFsH7oN1z8vvCVCb95fb87QgR46/zRLyN9Y3kg==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
+      "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@vue/shared": "3.5.34",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
+      "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.34",
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
+      "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@vue/compiler-core": "3.5.34",
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/compiler-ssr": "3.5.34",
+        "@vue/shared": "3.5.34",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.14",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
+      "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
+      "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
+      "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.34",
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
+      "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.34",
+        "@vue/runtime-core": "3.5.34",
+        "@vue/shared": "3.5.34",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
+      "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.34",
+        "@vue/shared": "3.5.34"
+      },
+      "peerDependencies": {
+        "vue": "3.5.34"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
+      "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.52.1.tgz",
+      "integrity": "sha512-fHA8+kXTbjagw3jkLiaS7KKrH8qe2DyOsiUhGlN4cdT77PEsfqXZl7ewDk1hsg+pJnPlnE50XtLxjR91iJOpmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/abtesting": "1.18.1",
+        "@algolia/client-abtesting": "5.52.1",
+        "@algolia/client-analytics": "5.52.1",
+        "@algolia/client-common": "5.52.1",
+        "@algolia/client-insights": "5.52.1",
+        "@algolia/client-personalization": "5.52.1",
+        "@algolia/client-query-suggestions": "5.52.1",
+        "@algolia/client-search": "5.52.1",
+        "@algolia/ingestion": "1.52.1",
+        "@algolia/monitoring": "1.52.1",
+        "@algolia/recommend": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
+      "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/compiler-sfc": "3.5.34",
+        "@vue/runtime-dom": "3.5.34",
+        "@vue/server-renderer": "3.5.34",
+        "@vue/shared": "3.5.34"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "homelog-docs",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "User documentation for HomeLog (docs.homelog.dev). Work in progress.",
+  "scripts": {
+    "docs:dev": "vitepress dev",
+    "docs:build": "vitepress build",
+    "docs:preview": "vitepress preview"
+  },
+  "devDependencies": {
+    "vitepress": "^1.6.3"
+  }
+}

--- a/docs-site/public/favicon.svg
+++ b/docs-site/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="8" fill="#211B16"/>
+  <path d="M16 7 L25 14.5 V25 H7 V14.5 Z" fill="none" stroke="#D9531E" stroke-width="2.2" stroke-linejoin="round"/>
+  <rect x="13.5" y="18" width="5" height="7" fill="#D9531E"/>
+</svg>

--- a/frontend/src/components/common/DemoBanner.vue
+++ b/frontend/src/components/common/DemoBanner.vue
@@ -11,20 +11,34 @@
       <span class="hidden sm:inline text-indigo-100 truncate">
         {{ t('demo.banner.description') }}
       </span>
-      <button
-        type="button"
-        class="ml-auto flex-shrink-0 inline-flex items-center gap-1.5 rounded-lg
-               bg-white/15 hover:bg-white/25 disabled:opacity-60
-               px-3 py-1 font-medium transition-colors"
-        :disabled="isResetting"
-        @click="onReset"
-      >
-        <svg class="w-4 h-4" :class="{ 'animate-spin': isResetting }" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-        </svg>
-        {{ isResetting ? t('demo.banner.resetting') : t('demo.banner.reset') }}
-      </button>
+      <div class="ml-auto flex items-center gap-2 flex-shrink-0">
+        <a
+          :href="links.github"
+          target="_blank"
+          rel="noopener"
+          class="inline-flex items-center gap-1.5 rounded-lg
+                 bg-white/15 hover:bg-white/25 px-3 py-1 font-medium transition-colors"
+        >
+          <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M12 .5C5.37.5 0 5.78 0 12.29c0 5.21 3.44 9.63 8.21 11.19.6.11.82-.25.82-.56 0-.28-.01-1.02-.02-2-3.34.71-4.04-1.58-4.04-1.58-.55-1.37-1.34-1.74-1.34-1.74-1.09-.73.08-.72.08-.72 1.21.08 1.84 1.22 1.84 1.22 1.07 1.8 2.81 1.28 3.5.98.11-.76.42-1.28.76-1.57-2.67-.3-5.47-1.31-5.47-5.84 0-1.29.47-2.34 1.24-3.17-.12-.3-.54-1.52.12-3.17 0 0 1.01-.32 3.3 1.21a11.6 11.6 0 0 1 3-.39c1.02 0 2.05.13 3 .39 2.29-1.53 3.3-1.21 3.3-1.21.66 1.65.24 2.87.12 3.17.77.83 1.24 1.88 1.24 3.17 0 4.54-2.81 5.54-5.49 5.83.43.36.81 1.08.81 2.18 0 1.57-.01 2.84-.01 3.23 0 .31.22.68.83.56A12.02 12.02 0 0 0 24 12.29C24 5.78 18.63.5 12 .5z" />
+          </svg>
+          <span class="hidden sm:inline">{{ t('demo.banner.selfHost') }}</span>
+        </a>
+        <button
+          type="button"
+          class="inline-flex items-center gap-1.5 rounded-lg
+                 bg-white/15 hover:bg-white/25 disabled:opacity-60
+                 px-3 py-1 font-medium transition-colors"
+          :disabled="isResetting"
+          @click="onReset"
+        >
+          <svg class="w-4 h-4" :class="{ 'animate-spin': isResetting }" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          </svg>
+          {{ isResetting ? t('demo.banner.resetting') : t('demo.banner.reset') }}
+        </button>
+      </div>
     </div>
   </div>
 </template>
@@ -33,6 +47,7 @@
 import { useI18n } from 'vue-i18n'
 import { useDemoMode } from '@/composables/useDemoMode'
 import { useConfirm } from '@/composables/useConfirm'
+import { LINKS as links } from '@/config/links'
 
 const { t } = useI18n()
 const { isDemoMode, isResetting, resetDemo } = useDemoMode()

--- a/frontend/src/components/settings/AboutSupportCard.vue
+++ b/frontend/src/components/settings/AboutSupportCard.vue
@@ -1,0 +1,59 @@
+<template>
+  <Card class="p-4 sm:p-6">
+    <div class="flex items-start gap-3">
+      <div class="text-2xl leading-none mt-0.5">🏠</div>
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2 flex-wrap">
+          <h3 class="font-semibold text-gray-900 dark:text-white">{{ t('settings.about.title') }}</h3>
+          <span v-if="appVersion" class="text-xs text-gray-400 dark:text-gray-500 tabular-nums">v{{ appVersion }}</span>
+          <a
+            v-if="updateAvailable"
+            :href="latestUrl || links.github"
+            target="_blank"
+            rel="noopener"
+            class="text-xs font-medium text-amber-600 dark:text-amber-400 hover:underline"
+          >
+            {{ t('settings.about.updateAvailable') }}
+          </a>
+        </div>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">{{ t('settings.about.tagline') }}</p>
+        <div class="flex flex-wrap gap-2 mt-3">
+          <a
+            :href="links.github"
+            target="_blank"
+            rel="noopener"
+            class="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium
+                   bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200
+                   hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+          >
+            <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M12 .5C5.37.5 0 5.78 0 12.29c0 5.21 3.44 9.63 8.21 11.19.6.11.82-.25.82-.56 0-.28-.01-1.02-.02-2-3.34.71-4.04-1.58-4.04-1.58-.55-1.37-1.34-1.74-1.34-1.74-1.09-.73.08-.72.08-.72 1.21.08 1.84 1.22 1.84 1.22 1.07 1.8 2.81 1.28 3.5.98.11-.76.42-1.28.76-1.57-2.67-.3-5.47-1.31-5.47-5.84 0-1.29.47-2.34 1.24-3.17-.12-.3-.54-1.52.12-3.17 0 0 1.01-.32 3.3 1.21a11.6 11.6 0 0 1 3-.39c1.02 0 2.05.13 3 .39 2.29-1.53 3.3-1.21 3.3-1.21.66 1.65.24 2.87.12 3.17.77.83 1.24 1.88 1.24 3.17 0 4.54-2.81 5.54-5.49 5.83.43.36.81 1.08.81 2.18 0 1.57-.01 2.84-.01 3.23 0 .31.22.68.83.56A12.02 12.02 0 0 0 24 12.29C24 5.78 18.63.5 12 .5z" />
+            </svg>
+            {{ t('settings.about.star') }}
+          </a>
+          <a
+            :href="links.kofi"
+            target="_blank"
+            rel="noopener"
+            class="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium
+                   bg-pink-100 dark:bg-pink-900/40 text-pink-700 dark:text-pink-300
+                   hover:bg-pink-200 dark:hover:bg-pink-900/60 transition-colors"
+          >
+            ❤️ {{ t('settings.about.donate') }}
+          </a>
+        </div>
+      </div>
+    </div>
+  </Card>
+</template>
+
+<script setup>
+import { useI18n } from 'vue-i18n'
+import { useDemoMode } from '@/composables/useDemoMode'
+import { LINKS as links } from '@/config/links'
+import Card from '@/components/common/Card.vue'
+
+const { t } = useI18n()
+// Version/update info comes from the single /version fetch done at app startup.
+const { appVersion, updateAvailable, latestUrl } = useDemoMode()
+</script>

--- a/frontend/src/composables/useDemoMode.js
+++ b/frontend/src/composables/useDemoMode.js
@@ -4,6 +4,10 @@ import { versionAPI, demoAPI } from '@/api/client'
 // Module-level state — fetched once and shared across every component.
 const isDemoMode = ref(false)
 const isResetting = ref(false)
+// Instance/version info, also sourced from the single /version call.
+const appVersion = ref('')
+const updateAvailable = ref(false)
+const latestUrl = ref('')
 let initialized = false
 
 // Credentials for the single shared demo account. Mirrors the backend
@@ -20,6 +24,9 @@ export function useDemoMode() {
     try {
       const { data } = await versionAPI.check()
       isDemoMode.value = !!data.demo_mode
+      appVersion.value = data.current && data.current !== 'dev' ? data.current : ''
+      updateAvailable.value = !!data.update_available
+      latestUrl.value = data.latest_url || ''
     } catch {
       // Version check is best-effort; default to non-demo on failure.
       isDemoMode.value = false
@@ -40,5 +47,5 @@ export function useDemoMode() {
     }
   }
 
-  return { isDemoMode, isResetting, initDemoMode, resetDemo }
+  return { isDemoMode, isResetting, appVersion, updateAvailable, latestUrl, initDemoMode, resetDemo }
 }

--- a/frontend/src/config/links.js
+++ b/frontend/src/config/links.js
@@ -1,0 +1,12 @@
+// Central registry of external project links (repo, demo, docs, funding).
+// Keep these in one place so the demo banner, login screen, settings "About"
+// card, and any future surface all point at the same canonical URLs.
+export const LINKS = {
+  github: 'https://github.com/sgiraz/homelog',
+  githubIssues: 'https://github.com/sgiraz/homelog/issues',
+  githubSponsors: 'https://github.com/sponsors/sgiraz',
+  kofi: 'https://ko-fi.com/sgiraz',
+  demo: 'https://demo.homelog.dev',
+  landing: 'https://homelog.dev',
+  docs: 'https://docs.homelog.dev',
+}

--- a/frontend/src/i18n/locales/en/demo.json
+++ b/frontend/src/i18n/locales/en/demo.json
@@ -2,6 +2,7 @@
   "banner": {
     "label": "Demo mode",
     "description": "Sample data resets every hour — any changes you make are temporary.",
+    "selfHost": "Self-host",
     "reset": "Reset demo data",
     "resetting": "Resetting…"
   },
@@ -13,6 +14,8 @@
   "login": {
     "title": "Try the live demo",
     "description": "Explore HomeLog with realistic sample data — no signup required.",
-    "button": "Enter demo"
+    "button": "Enter demo",
+    "selfHostPrompt": "Like it and want it for your own home?",
+    "selfHostLink": "Self-host it from GitHub"
   }
 }

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -20,6 +20,13 @@
     "categories": "Categories",
     "data": "Data"
   },
+  "about": {
+    "title": "About & Support",
+    "tagline": "HomeLog is free and open-source. If it helps your household, consider supporting its development.",
+    "updateAvailable": "Update available",
+    "star": "Star on GitHub",
+    "donate": "Donate"
+  },
   "preferences": {
     "title": "Personal Preferences",
     "theme": "Theme",

--- a/frontend/src/i18n/locales/it/demo.json
+++ b/frontend/src/i18n/locales/it/demo.json
@@ -2,6 +2,7 @@
   "banner": {
     "label": "Modalità demo",
     "description": "I dati di esempio si resettano ogni ora — le modifiche che fai sono temporanee.",
+    "selfHost": "Self-host",
     "reset": "Reset dati demo",
     "resetting": "Reset in corso…"
   },
@@ -13,6 +14,8 @@
   "login": {
     "title": "Prova la demo live",
     "description": "Esplora HomeLog con dati di esempio realistici — nessuna registrazione necessaria.",
-    "button": "Entra nella demo"
+    "button": "Entra nella demo",
+    "selfHostPrompt": "Ti piace e la vuoi a casa tua?",
+    "selfHostLink": "Installala da GitHub"
   }
 }

--- a/frontend/src/i18n/locales/it/settings.json
+++ b/frontend/src/i18n/locales/it/settings.json
@@ -20,6 +20,13 @@
     "categories": "Categorie",
     "data": "Dati"
   },
+  "about": {
+    "title": "Info e supporto",
+    "tagline": "HomeLog è gratuito e open-source. Se è utile alla tua famiglia, valuta di sostenerne lo sviluppo.",
+    "updateAvailable": "Aggiornamento disponibile",
+    "star": "Stella su GitHub",
+    "donate": "Dona"
+  },
   "preferences": {
     "title": "Preferenze Personali",
     "theme": "Tema",

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -20,6 +20,17 @@
         <Button class="w-full" :disabled="loading" @click="enterDemo">
           {{ t('demo.login.button') }}
         </Button>
+        <p class="text-xs text-indigo-700 dark:text-indigo-400 pt-1">
+          {{ t('demo.login.selfHostPrompt') }}
+          <a
+            :href="links.github"
+            target="_blank"
+            rel="noopener"
+            class="font-semibold underline hover:no-underline"
+          >
+            {{ t('demo.login.selfHostLink') }}
+          </a>
+        </p>
       </div>
 
       <!-- ── Login / Register ── -->
@@ -214,6 +225,7 @@ import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '@/stores/auth'
 import { authAPI } from '@/api/client'
 import { useDemoMode, DEMO_EMAIL, DEMO_PASSWORD } from '@/composables/useDemoMode'
+import { LINKS as links } from '@/config/links'
 import Card from '@/components/common/Card.vue'
 import Input from '@/components/common/Input.vue'
 import Button from '@/components/common/Button.vue'

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -101,6 +101,9 @@
     <!-- Tab: Dati -->
     <DataTab v-show="activeTab === 'dati'" />
 
+    <!-- About / Support the project (always visible, all instances) -->
+    <AboutSupportCard />
+
     <!-- Avatar Crop Modal -->
     <AvatarCropModal
       v-if="showCropModal"
@@ -127,6 +130,7 @@ import PropertiesTab from '@/components/settings/PropertiesTab.vue'
 import PreferencesTab from '@/components/settings/PreferencesTab.vue'
 import CategoriesTab from '@/components/settings/CategoriesTab.vue'
 import DataTab from '@/components/settings/DataTab.vue'
+import AboutSupportCard from '@/components/settings/AboutSupportCard.vue'
 
 const { t } = useI18n()
 const authStore = useAuthStore()

--- a/landing/favicon.svg
+++ b/landing/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="8" fill="#211B16"/>
+  <path d="M16 7 L25 14.5 V25 H7 V14.5 Z" fill="none" stroke="#D9531E" stroke-width="2.2" stroke-linejoin="round"/>
+  <rect x="13.5" y="18" width="5" height="7" fill="#D9531E"/>
+</svg>

--- a/landing/index.html
+++ b/landing/index.html
@@ -1,0 +1,494 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>HomeLog — Your home's expenses, in one place</title>
+  <meta name="description" content="Self-hosted expense splitting, utility bills and meter readings for families. Free, open-source, and runs on a Raspberry Pi." />
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="HomeLog — Your home's expenses, in one place" />
+  <meta property="og:description" content="Self-hosted expense splitting, utility bills and meter readings for families. Free and open-source." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://homelog.dev" />
+
+  <link rel="icon" href="favicon.svg" type="image/svg+xml" />
+
+  <!-- Fonts: Fraunces (display serif), Hanken Grotesk (body), Space Mono (numerals) -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,700;1,9..144,500&family=Hanken+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            display: ['Fraunces', 'serif'],
+            sans: ['"Hanken Grotesk"', 'system-ui', 'sans-serif'],
+            mono: ['"Space Mono"', 'monospace'],
+          },
+          colors: {
+            paper: '#FBF6EC',
+            'paper-2': '#F4ECDC',
+            ink: '#211B16',
+            'ink-soft': '#6B5F52',
+            ember: '#D9531E',
+            'ember-deep': '#B23F12',
+            pine: '#234E3A',
+            line: '#E3D7C3',
+          },
+        },
+      },
+    }
+  </script>
+
+  <style>
+    :root { color-scheme: light; }
+    body { background: #FBF6EC; color: #211B16; font-family: 'Hanken Grotesk', system-ui, sans-serif; }
+
+    /* Paper grain overlay */
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      z-index: 0;
+      pointer-events: none;
+      opacity: 0.4;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
+      mix-blend-mode: multiply;
+    }
+
+    /* Warm radial glow behind the hero */
+    .hero-glow {
+      position: absolute;
+      inset: -20% -10% auto -10%;
+      height: 120%;
+      z-index: 0;
+      pointer-events: none;
+      background:
+        radial-gradient(60% 50% at 75% 15%, rgba(217, 83, 30, 0.16), transparent 70%),
+        radial-gradient(50% 50% at 15% 0%, rgba(35, 78, 58, 0.10), transparent 70%);
+    }
+
+    /* Ledger hairlines */
+    .ledger-line { border-bottom: 1px solid #E3D7C3; }
+
+    /* Staggered load reveal */
+    @keyframes fadeUp { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: none; } }
+    .reveal { opacity: 0; animation: fadeUp 0.8s cubic-bezier(0.22, 1, 0.36, 1) forwards; }
+    @media (prefers-reduced-motion: reduce) { .reveal { animation: none; opacity: 1; } }
+
+    /* Floating balance card */
+    @keyframes floaty { 0%, 100% { transform: translateY(0) rotate(-1.5deg); } 50% { transform: translateY(-10px) rotate(-1.5deg); } }
+    .floaty { animation: floaty 7s ease-in-out infinite; }
+    @media (prefers-reduced-motion: reduce) { .floaty { animation: none; } }
+
+    /* Work-in-progress diagonal ribbon */
+    .wip-ribbon {
+      position: absolute; top: 26px; right: -54px;
+      transform: rotate(45deg);
+      background: #211B16; color: #FBF6EC;
+      font-family: 'Space Mono', monospace; font-size: 11px; letter-spacing: 0.18em;
+      padding: 7px 64px; text-transform: uppercase;
+      box-shadow: 0 6px 18px rgba(33, 27, 22, 0.25);
+    }
+
+    .link-underline { background-image: linear-gradient(currentColor, currentColor); background-size: 0% 1.5px; background-repeat: no-repeat; background-position: 0 100%; transition: background-size 0.3s ease; }
+    .link-underline:hover { background-size: 100% 1.5px; }
+
+    .card-lift { transition: transform 0.3s cubic-bezier(0.22,1,0.36,1), box-shadow 0.3s ease; }
+    .card-lift:hover { transform: translateY(-4px); box-shadow: 0 18px 40px -18px rgba(33,27,22,0.35); }
+
+    .lang-select { appearance: none; -webkit-appearance: none; }
+  </style>
+</head>
+
+<body class="font-sans antialiased text-ink selection:bg-ember selection:text-paper">
+
+  <!-- ░░ WIP notice bar ░░ -->
+  <div class="relative z-20 bg-ink text-paper text-center text-xs sm:text-sm font-mono tracking-wide py-2 px-4" data-i18n-html="wipbar">
+    🚧 Work in progress — this site and the <a href="https://docs.homelog.dev" class="underline underline-offset-2 hover:text-ember transition-colors">docs</a> are still being built.
+  </div>
+
+  <!-- ░░ Nav ░░ -->
+  <header class="relative z-20 max-w-6xl mx-auto px-6 py-6 flex items-center justify-between gap-4">
+    <a href="/" class="flex items-center gap-2.5 group shrink-0">
+      <span class="grid place-items-center w-9 h-9 rounded-xl bg-ink text-paper text-lg group-hover:bg-ember transition-colors">⌂</span>
+      <span class="font-display text-2xl font-semibold tracking-tight">HomeLog</span>
+    </a>
+    <nav class="flex items-center gap-4 sm:gap-6 text-sm font-medium">
+      <a href="https://docs.homelog.dev" class="hidden sm:inline link-underline text-ink-soft hover:text-ink" data-i18n="nav.docs">Docs</a>
+      <a href="https://github.com/sgiraz/homelog" class="link-underline text-ink-soft hover:text-ink">GitHub</a>
+
+      <!-- Language selector -->
+      <label class="relative inline-flex items-center">
+        <span class="sr-only" data-i18n="nav.language">Language</span>
+        <select id="lang-select" aria-label="Language"
+                class="lang-select bg-transparent border border-ink/20 hover:border-ink/60 rounded-full pl-3 pr-7 py-1.5 cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-ember/40">
+          <option value="en">EN</option>
+          <option value="it">IT</option>
+        </select>
+        <span class="pointer-events-none absolute right-2.5 text-ink-soft text-[10px]">▼</span>
+      </label>
+
+      <a href="https://demo.homelog.dev" class="inline-flex items-center gap-1.5 rounded-full bg-ink text-paper px-4 py-2 hover:bg-ember transition-colors">
+        <span data-i18n="nav.demo">Live demo</span>
+        <span aria-hidden="true">→</span>
+      </a>
+    </nav>
+  </header>
+
+  <!-- ░░ Hero ░░ -->
+  <section class="relative overflow-hidden">
+    <div class="hero-glow"></div>
+    <div class="relative z-10 max-w-6xl mx-auto px-6 pt-10 pb-20 sm:pt-16 sm:pb-28 grid lg:grid-cols-[1.05fr_0.95fr] gap-14 lg:gap-10 items-center">
+
+      <!-- Copy -->
+      <div>
+        <p class="reveal font-mono text-xs sm:text-sm tracking-[0.22em] uppercase text-ember-deep mb-5" style="animation-delay:.05s" data-i18n="hero.kicker">
+          Self-hosted · Open-source
+        </p>
+        <h1 class="reveal font-display font-semibold tracking-tight leading-[0.98] text-[2.7rem] sm:text-6xl lg:text-[4.4rem]" style="animation-delay:.12s" data-i18n-html="hero.title">
+          Every euro that<br />
+          <span class="italic text-ember">runs your home</span>,<br />
+          in one ledger.
+        </h1>
+        <p class="reveal mt-7 text-lg sm:text-xl text-ink-soft max-w-xl leading-relaxed" style="animation-delay:.2s" data-i18n-html="hero.sub">
+          HomeLog tracks shared expenses, utility bills and meter readings for the
+          whole family — then settles up who owes what. Your data lives on
+          <em class="font-display not-italic font-semibold text-ink">your</em> server, not in someone else's cloud.
+        </p>
+
+        <div class="reveal mt-9 flex flex-wrap items-center gap-3.5" style="animation-delay:.28s">
+          <a href="https://demo.homelog.dev"
+             class="group inline-flex items-center gap-2 rounded-full bg-ember text-paper font-semibold px-6 py-3.5 shadow-[0_12px_30px_-10px_rgba(217,83,30,0.7)] hover:bg-ember-deep transition-colors">
+            <span data-i18n="hero.ctaDemo">Try the live demo</span>
+            <span class="transition-transform group-hover:translate-x-1" aria-hidden="true">→</span>
+          </a>
+          <a href="https://github.com/sgiraz/homelog"
+             class="inline-flex items-center gap-2 rounded-full border border-ink/20 hover:border-ink/60 px-6 py-3.5 font-semibold transition-colors">
+            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.37.5 0 5.78 0 12.29c0 5.21 3.44 9.63 8.21 11.19.6.11.82-.25.82-.56 0-.28-.01-1.02-.02-2-3.34.71-4.04-1.58-4.04-1.58-.55-1.37-1.34-1.74-1.34-1.74-1.09-.73.08-.72.08-.72 1.21.08 1.84 1.22 1.84 1.22 1.07 1.8 2.81 1.28 3.5.98.11-.76.42-1.28.76-1.57-2.67-.3-5.47-1.31-5.47-5.84 0-1.29.47-2.34 1.24-3.17-.12-.3-.54-1.52.12-3.17 0 0 1.01-.32 3.3 1.21a11.6 11.6 0 0 1 3-.39c1.02 0 2.05.13 3 .39 2.29-1.53 3.3-1.21 3.3-1.21.66 1.65.24 2.87.12 3.17.77.83 1.24 1.88 1.24 3.17 0 4.54-2.81 5.54-5.49 5.83.43.36.81 1.08.81 2.18 0 1.57-.01 2.84-.01 3.23 0 .31.22.68.83.56A12.02 12.02 0 0 0 24 12.29C24 5.78 18.63.5 12 .5z"/></svg>
+            <span data-i18n="hero.ctaSelfhost">Self-host it</span>
+          </a>
+        </div>
+
+        <p class="reveal mt-6 font-mono text-xs text-ink-soft" style="animation-delay:.36s" data-i18n-html="hero.note">
+          ✦ Free forever &nbsp;·&nbsp; ✦ Runs on a Raspberry Pi &nbsp;·&nbsp; ✦ AGPL-3.0
+        </p>
+      </div>
+
+      <!-- Ledger card visual -->
+      <div class="reveal relative" style="animation-delay:.3s">
+        <div class="wip-ribbon" data-i18n="wipRibbon">Work in progress</div>
+        <div class="floaty relative bg-paper rounded-[1.6rem] border border-line shadow-[0_30px_60px_-25px_rgba(33,27,22,0.45)] p-6 sm:p-7 max-w-md mx-auto">
+          <div class="flex items-baseline justify-between mb-1">
+            <span class="font-display text-xl font-semibold" data-i18n="card.balanceTitle">Household balance</span>
+            <span class="font-mono text-xs text-pine bg-pine/10 rounded-full px-2.5 py-1" data-i18n="card.period">May 2026</span>
+          </div>
+          <p class="text-sm text-ink-soft mb-5" data-i18n="card.sharedBetween">Shared between Simone &amp; Giulia</p>
+
+          <div class="space-y-0.5 font-mono text-sm">
+            <div class="flex items-center justify-between py-2.5 ledger-line">
+              <span class="flex items-center gap-2.5"><span>⚡</span> <span data-i18n="card.electricity">Electricity</span></span>
+              <span class="tabular-nums">€ 84,20</span>
+            </div>
+            <div class="flex items-center justify-between py-2.5 ledger-line">
+              <span class="flex items-center gap-2.5"><span>🔥</span> <span data-i18n="card.gas">Gas</span></span>
+              <span class="tabular-nums">€ 145,80</span>
+            </div>
+            <div class="flex items-center justify-between py-2.5 ledger-line">
+              <span class="flex items-center gap-2.5"><span>💧</span> <span data-i18n="card.water">Water</span></span>
+              <span class="tabular-nums">€ 58,20</span>
+            </div>
+            <div class="flex items-center justify-between py-2.5">
+              <span class="flex items-center gap-2.5"><span>🛒</span> <span data-i18n="card.groceries">Groceries</span></span>
+              <span class="tabular-nums">€ 996,30</span>
+            </div>
+          </div>
+
+          <div class="mt-4 pt-4 border-t-2 border-dashed border-line flex items-end justify-between">
+            <span class="font-display font-semibold text-lg" data-i18n="card.thisMonth">This month</span>
+            <span class="font-mono text-2xl font-bold text-ember tabular-nums">€ 1.284,50</span>
+          </div>
+        </div>
+
+        <!-- Floating "bill matched" toast -->
+        <div class="hidden sm:flex absolute -bottom-6 -left-4 items-center gap-3 bg-ink text-paper rounded-2xl px-4 py-3 shadow-xl rotate-2">
+          <span class="grid place-items-center w-8 h-8 rounded-lg bg-pine text-paper">✓</span>
+          <div class="leading-tight">
+            <div class="text-sm font-semibold" data-i18n="toast.title">Bill matched to reading</div>
+            <div class="font-mono text-[11px] text-paper/70">GAS-771-2025 · 190 Smc</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ░░ Features ░░ -->
+  <section class="relative z-10 bg-paper-2 border-y border-line">
+    <div class="max-w-6xl mx-auto px-6 py-20 sm:py-24">
+      <div class="max-w-2xl mb-14">
+        <p class="font-mono text-xs tracking-[0.22em] uppercase text-ember-deep mb-3" data-i18n="features.kicker">What's inside</p>
+        <h2 class="font-display text-3xl sm:text-4xl font-semibold tracking-tight" data-i18n="features.title">
+          One app for the money that keeps a household running.
+        </h2>
+      </div>
+
+      <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
+        <div class="card-lift bg-paper rounded-2xl border border-line p-6">
+          <div class="text-2xl mb-4">🤝</div>
+          <h3 class="font-display text-xl font-semibold mb-2" data-i18n="feat1.title">Expense splitting</h3>
+          <p class="text-ink-soft text-[15px] leading-relaxed" data-i18n="feat1.body">Split costs between household members, track balances, and settle up — no more "who paid for what".</p>
+        </div>
+        <div class="card-lift bg-paper rounded-2xl border border-line p-6">
+          <div class="text-2xl mb-4">⚡</div>
+          <h3 class="font-display text-xl font-semibold mb-2" data-i18n="feat2.title">Utilities &amp; bills</h3>
+          <p class="text-ink-soft text-[15px] leading-relaxed" data-i18n="feat2.body">Electricity, gas and water — log meter readings, store bills, and watch consumption trends over time.</p>
+        </div>
+        <div class="card-lift bg-paper rounded-2xl border border-line p-6">
+          <div class="text-2xl mb-4">📄</div>
+          <h3 class="font-display text-xl font-semibold mb-2" data-i18n="feat3.title">PDF bill templates</h3>
+          <p class="text-ink-soft text-[15px] leading-relaxed" data-i18n="feat3.body">Teach HomeLog to read your provider's bills once with a drag-and-drop wizard; it auto-extracts every figure after that.</p>
+        </div>
+        <div class="card-lift bg-paper rounded-2xl border border-line p-6">
+          <div class="text-2xl mb-4">📊</div>
+          <h3 class="font-display text-xl font-semibold mb-2" data-i18n="feat4.title">Consumption analysis</h3>
+          <p class="text-ink-soft text-[15px] leading-relaxed" data-i18n="feat4.body">Compare billed vs. actual consumption, spot anomalies, and see exactly where your money goes each period.</p>
+        </div>
+        <div class="card-lift bg-paper rounded-2xl border border-line p-6">
+          <div class="text-2xl mb-4">🌍</div>
+          <h3 class="font-display text-xl font-semibold mb-2" data-i18n="feat5.title">Multi-currency &amp; language</h3>
+          <p class="text-ink-soft text-[15px] leading-relaxed" data-i18n="feat5.body">Italian &amp; English UI with locale-aware numbers, dates and currencies — per expense and per service.</p>
+        </div>
+        <div class="card-lift bg-paper rounded-2xl border border-line p-6">
+          <div class="text-2xl mb-4">🔒</div>
+          <h3 class="font-display text-xl font-semibold mb-2" data-i18n="feat6.title">Yours, privately</h3>
+          <p class="text-ink-soft text-[15px] leading-relaxed" data-i18n="feat6.body">Self-hosted in a single Docker container. Your family's finances never leave the hardware you control.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ░░ Positioning ░░ -->
+  <section class="relative z-10 max-w-6xl mx-auto px-6 py-20 sm:py-28">
+    <div class="grid lg:grid-cols-[0.9fr_1.1fr] gap-12 items-center">
+      <div>
+        <p class="font-mono text-xs tracking-[0.22em] uppercase text-ember-deep mb-3" data-i18n="why.kicker">Why HomeLog</p>
+        <h2 class="font-display text-3xl sm:text-4xl font-semibold tracking-tight leading-tight" data-i18n="why.title">
+          Splitwise meets your utility bills — without the cloud.
+        </h2>
+        <p class="mt-6 text-lg text-ink-soft leading-relaxed" data-i18n="why.body">
+          Expense-splitting apps live in the cloud and ignore your bills. Budgeting
+          tools ignore your family. HomeLog ties shared expenses, meter readings and
+          provider bills together — and runs entirely on hardware you own, down to a
+          Raspberry Pi in the closet.
+        </p>
+        <a href="https://github.com/sgiraz/homelog/blob/main/DEPLOY-GUIDE.md"
+           class="inline-flex items-center gap-2 mt-8 font-semibold link-underline text-ember-deep">
+          <span data-i18n="why.link">Read the deploy guide</span>
+          <span aria-hidden="true">→</span>
+        </a>
+      </div>
+
+      <div class="grid sm:grid-cols-2 gap-4 font-mono text-sm">
+        <div class="bg-pine text-paper rounded-2xl p-6">
+          <div class="text-3xl font-bold">256<span class="text-base font-normal opacity-70"> MB</span></div>
+          <p class="mt-2 text-paper/75 leading-snug" data-i18n="stat1.body">Runs comfortably in a single low-memory container.</p>
+        </div>
+        <div class="bg-paper border border-line rounded-2xl p-6">
+          <div class="text-3xl font-bold text-ember">2</div>
+          <p class="mt-2 text-ink-soft leading-snug" data-i18n="stat2.body">Languages today — Italian &amp; English, more welcome.</p>
+        </div>
+        <div class="bg-paper border border-line rounded-2xl p-6">
+          <div class="text-3xl font-bold">1</div>
+          <p class="mt-2 text-ink-soft leading-snug" data-i18n-html="stat3.body"><code>docker compose up</code> — one container, API + UI.</p>
+        </div>
+        <div class="bg-ink text-paper rounded-2xl p-6">
+          <div class="text-3xl font-bold text-ember">∞</div>
+          <p class="mt-2 text-paper/75 leading-snug" data-i18n="stat4.body">Households, members &amp; properties. No seats, no fees.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ░░ CTA band ░░ -->
+  <section class="relative z-10 overflow-hidden bg-ink text-paper">
+    <div class="max-w-6xl mx-auto px-6 py-20 sm:py-24 text-center">
+      <h2 class="font-display text-3xl sm:text-5xl font-semibold tracking-tight" data-i18n="cta.title">
+        Try it now. Host it forever.
+      </h2>
+      <p class="mt-5 text-lg text-paper/70 max-w-xl mx-auto" data-i18n="cta.body">
+        Poke around the live demo with sample data, then deploy your own private
+        instance from GitHub in minutes.
+      </p>
+      <div class="mt-10 flex flex-wrap items-center justify-center gap-4">
+        <a href="https://demo.homelog.dev" class="rounded-full bg-ember text-paper font-semibold px-7 py-4 hover:bg-ember-deep transition-colors" data-i18n="cta.demo">Open the live demo</a>
+        <a href="https://github.com/sgiraz/homelog" class="rounded-full border border-paper/30 hover:border-paper px-7 py-4 font-semibold transition-colors" data-i18n="cta.github">View on GitHub</a>
+        <a href="https://ko-fi.com/sgiraz" class="inline-flex items-center gap-2 rounded-full bg-paper/10 hover:bg-paper/20 px-7 py-4 font-semibold transition-colors" data-i18n="cta.support">❤️ Support the project</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- ░░ Footer ░░ -->
+  <footer class="relative z-10 bg-paper">
+    <div class="max-w-6xl mx-auto px-6 py-12 flex flex-col sm:flex-row items-center justify-between gap-6 text-sm text-ink-soft">
+      <div class="flex items-center gap-2.5">
+        <span class="grid place-items-center w-7 h-7 rounded-lg bg-ink text-paper">⌂</span>
+        <span class="font-display text-lg font-semibold text-ink">HomeLog</span>
+        <span class="font-mono text-xs ml-2 px-2 py-0.5 rounded-full bg-paper-2 border border-line">WIP</span>
+      </div>
+      <nav class="flex flex-wrap items-center justify-center gap-x-6 gap-y-2">
+        <a href="https://demo.homelog.dev" class="link-underline hover:text-ink">Demo</a>
+        <a href="https://docs.homelog.dev" class="link-underline hover:text-ink" data-i18n="footer.docs">Docs</a>
+        <a href="https://github.com/sgiraz/homelog" class="link-underline hover:text-ink">GitHub</a>
+        <a href="https://ko-fi.com/sgiraz" class="link-underline hover:text-ink" data-i18n="footer.donate">Donate</a>
+        <a href="https://github.com/sgiraz/homelog/blob/main/LICENSE" class="link-underline hover:text-ink">AGPL-3.0</a>
+      </nav>
+      <p class="font-mono text-xs" data-i18n="footer.tagline">Made with care for the home.</p>
+    </div>
+  </footer>
+
+  <!-- ░░ i18n (IT / EN), default = browser language, choice persisted ░░ -->
+  <script>
+    const I18N = {
+      en: {
+        'wipbar': '🚧 Work in progress — this site and the <a href="https://docs.homelog.dev" class="underline underline-offset-2 hover:text-ember transition-colors">docs</a> are still being built.',
+        'nav.docs': 'Docs',
+        'nav.demo': 'Live demo',
+        'nav.language': 'Language',
+        'hero.kicker': 'Self-hosted · Open-source',
+        'hero.title': 'Every euro that<br /><span class="italic text-ember">runs your home</span>,<br />in one ledger.',
+        'hero.sub': 'HomeLog tracks shared expenses, utility bills and meter readings for the whole family — then settles up who owes what. Your data lives on <em class="font-display not-italic font-semibold text-ink">your</em> server, not in someone else\'s cloud.',
+        'hero.ctaDemo': 'Try the live demo',
+        'hero.ctaSelfhost': 'Self-host it',
+        'hero.note': '✦ Free forever &nbsp;·&nbsp; ✦ Runs on a Raspberry Pi &nbsp;·&nbsp; ✦ AGPL-3.0',
+        'card.balanceTitle': 'Household balance',
+        'card.period': 'May 2026',
+        'card.sharedBetween': 'Shared between Simone & Giulia',
+        'card.electricity': 'Electricity',
+        'card.gas': 'Gas',
+        'card.water': 'Water',
+        'card.groceries': 'Groceries',
+        'card.thisMonth': 'This month',
+        'toast.title': 'Bill matched to reading',
+        'wipRibbon': 'Work in progress',
+        'features.kicker': "What's inside",
+        'features.title': 'One app for the money that keeps a household running.',
+        'feat1.title': 'Expense splitting',
+        'feat1.body': 'Split costs between household members, track balances, and settle up — no more "who paid for what".',
+        'feat2.title': 'Utilities & bills',
+        'feat2.body': 'Electricity, gas and water — log meter readings, store bills, and watch consumption trends over time.',
+        'feat3.title': 'PDF bill templates',
+        'feat3.body': "Teach HomeLog to read your provider's bills once with a drag-and-drop wizard; it auto-extracts every figure after that.",
+        'feat4.title': 'Consumption analysis',
+        'feat4.body': 'Compare billed vs. actual consumption, spot anomalies, and see exactly where your money goes each period.',
+        'feat5.title': 'Multi-currency & language',
+        'feat5.body': 'Italian & English UI with locale-aware numbers, dates and currencies — per expense and per service.',
+        'feat6.title': 'Yours, privately',
+        'feat6.body': "Self-hosted in a single Docker container. Your family's finances never leave the hardware you control.",
+        'why.kicker': 'Why HomeLog',
+        'why.title': 'Splitwise meets your utility bills — without the cloud.',
+        'why.body': 'Expense-splitting apps live in the cloud and ignore your bills. Budgeting tools ignore your family. HomeLog ties shared expenses, meter readings and provider bills together — and runs entirely on hardware you own, down to a Raspberry Pi in the closet.',
+        'why.link': 'Read the deploy guide',
+        'stat1.body': 'Runs comfortably in a single low-memory container.',
+        'stat2.body': 'Languages today — Italian & English, more welcome.',
+        'stat3.body': '<code>docker compose up</code> — one container, API + UI.',
+        'stat4.body': 'Households, members & properties. No seats, no fees.',
+        'cta.title': 'Try it now. Host it forever.',
+        'cta.body': 'Poke around the live demo with sample data, then deploy your own private instance from GitHub in minutes.',
+        'cta.demo': 'Open the live demo',
+        'cta.github': 'View on GitHub',
+        'cta.support': '❤️ Support the project',
+        'footer.docs': 'Docs',
+        'footer.donate': 'Donate',
+        'footer.tagline': 'Made with care for the home.',
+      },
+      it: {
+        'wipbar': '🚧 Lavori in corso — questo sito e la <a href="https://docs.homelog.dev" class="underline underline-offset-2 hover:text-ember transition-colors">documentazione</a> sono ancora in costruzione.',
+        'nav.docs': 'Documentazione',
+        'nav.demo': 'Demo live',
+        'nav.language': 'Lingua',
+        'hero.kicker': 'Self-hosted · Open-source',
+        'hero.title': 'Ogni euro che<br /><span class="italic text-ember">manda avanti casa</span>,<br />in un solo registro.',
+        'hero.sub': 'HomeLog tiene traccia di spese condivise, bollette e letture dei contatori per tutta la famiglia — poi calcola chi deve cosa. I tuoi dati vivono sul <em class="font-display not-italic font-semibold text-ink">tuo</em> server, non nel cloud di qualcun altro.',
+        'hero.ctaDemo': 'Prova la demo live',
+        'hero.ctaSelfhost': 'Installalo da te',
+        'hero.note': '✦ Gratis per sempre &nbsp;·&nbsp; ✦ Gira su un Raspberry Pi &nbsp;·&nbsp; ✦ AGPL-3.0',
+        'card.balanceTitle': 'Bilancio famiglia',
+        'card.period': 'Mag 2026',
+        'card.sharedBetween': 'Diviso tra Simone e Giulia',
+        'card.electricity': 'Luce',
+        'card.gas': 'Gas',
+        'card.water': 'Acqua',
+        'card.groceries': 'Spesa',
+        'card.thisMonth': 'Questo mese',
+        'toast.title': 'Bolletta abbinata alla lettura',
+        'wipRibbon': 'Lavori in corso',
+        'features.kicker': "Cosa c'è dentro",
+        'features.title': "Un'unica app per il denaro che manda avanti una casa.",
+        'feat1.title': 'Divisione delle spese',
+        'feat1.body': 'Dividi i costi tra i membri, tieni traccia dei saldi e pareggia i conti — basta con il "chi ha pagato cosa".',
+        'feat2.title': 'Utenze e bollette',
+        'feat2.body': "Luce, gas e acqua — registra le letture, archivia le bollette e osserva l'andamento dei consumi nel tempo.",
+        'feat3.title': 'Template PDF delle bollette',
+        'feat3.body': 'Insegna a HomeLog a leggere le bollette del tuo fornitore una volta sola con un wizard drag-and-drop; dopo estrae ogni dato da solo.',
+        'feat4.title': 'Analisi dei consumi',
+        'feat4.body': 'Confronta consumo fatturato ed effettivo, individua le anomalie e vedi esattamente dove vanno i tuoi soldi ogni periodo.',
+        'feat5.title': 'Multi-valuta e lingua',
+        'feat5.body': 'Interfaccia in italiano e inglese con numeri, date e valute localizzati — per spesa e per servizio.',
+        'feat6.title': 'Tuo, e privato',
+        'feat6.body': "Self-hosted in un singolo container Docker. Le finanze della tua famiglia non lasciano mai l'hardware che controlli tu.",
+        'why.kicker': 'Perché HomeLog',
+        'why.title': 'Splitwise incontra le tue bollette — senza il cloud.',
+        'why.body': 'Le app per dividere le spese vivono nel cloud e ignorano le bollette. I tool di budgeting ignorano la famiglia. HomeLog mette insieme spese condivise, letture dei contatori e bollette del fornitore — e gira interamente su hardware tuo, fino a un Raspberry Pi nello sgabuzzino.',
+        'why.link': 'Leggi la guida al deploy',
+        'stat1.body': 'Gira comodamente in un singolo container a bassa memoria.',
+        'stat2.body': 'Lingue oggi — italiano e inglese, altre benvenute.',
+        'stat3.body': '<code>docker compose up</code> — un container, API + UI.',
+        'stat4.body': 'Nuclei, membri e proprietà. Nessun posto a pagamento, nessuna fee.',
+        'cta.title': 'Provalo ora. Ospitalo per sempre.',
+        'cta.body': 'Esplora la demo live con dati di esempio, poi installa la tua istanza privata da GitHub in pochi minuti.',
+        'cta.demo': 'Apri la demo live',
+        'cta.github': 'Guarda su GitHub',
+        'cta.support': '❤️ Sostieni il progetto',
+        'footer.docs': 'Documentazione',
+        'footer.donate': 'Dona',
+        'footer.tagline': 'Fatto con cura per la casa.',
+      },
+    };
+
+    function applyLang(lang) {
+      const dict = I18N[lang] || I18N.en;
+      document.documentElement.lang = lang;
+      document.querySelectorAll('[data-i18n]').forEach(function (el) {
+        const k = el.getAttribute('data-i18n');
+        if (dict[k] != null) el.textContent = dict[k];
+      });
+      document.querySelectorAll('[data-i18n-html]').forEach(function (el) {
+        const k = el.getAttribute('data-i18n-html');
+        if (dict[k] != null) el.innerHTML = dict[k];
+      });
+      const sel = document.getElementById('lang-select');
+      if (sel) sel.value = lang;
+    }
+
+    (function () {
+      const stored = localStorage.getItem('homelog-lang');
+      const browser = (navigator.language || 'en').toLowerCase().indexOf('it') === 0 ? 'it' : 'en';
+      applyLang(stored || browser);
+
+      const sel = document.getElementById('lang-select');
+      if (sel) {
+        sel.addEventListener('change', function (e) {
+          const l = e.target.value;
+          localStorage.setItem('homelog-lang', l);
+          applyLang(l);
+        });
+      }
+    })();
+  </script>
+
+</body>
+</html>

--- a/landing/index.html
+++ b/landing/index.html
@@ -125,12 +125,12 @@
       <!-- Language selector -->
       <label class="relative inline-flex items-center">
         <span class="sr-only" data-i18n="nav.language">Language</span>
-        <select id="lang-select" aria-label="Language"
+        <select id="lang-select"
                 class="lang-select bg-transparent border border-ink/20 hover:border-ink/60 rounded-full pl-3 pr-7 py-1.5 cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-ember/40">
           <option value="en">EN</option>
           <option value="it">IT</option>
         </select>
-        <span class="pointer-events-none absolute right-2.5 text-ink-soft text-[10px]">▼</span>
+        <span class="pointer-events-none absolute right-2.5 text-ink-soft text-[10px]" aria-hidden="true">▼</span>
       </label>
 
       <a href="https://demo.homelog.dev" class="inline-flex items-center gap-1.5 rounded-full bg-ink text-paper px-4 py-2 hover:bg-ember transition-colors">
@@ -474,16 +474,24 @@
       if (sel) sel.value = lang;
     }
 
+    // Storage access can throw (Safari private mode, blocked storage) — never
+    // let that break the language switcher; just fall back to no persistence.
+    function storedLang() {
+      try { return localStorage.getItem('homelog-lang'); } catch (e) { return null; }
+    }
+    function saveLang(l) {
+      try { localStorage.setItem('homelog-lang', l); } catch (e) { /* storage unavailable */ }
+    }
+
     (function () {
-      const stored = localStorage.getItem('homelog-lang');
       const browser = (navigator.language || 'en').toLowerCase().indexOf('it') === 0 ? 'it' : 'en';
-      applyLang(stored || browser);
+      applyLang(storedLang() || browser);
 
       const sel = document.getElementById('lang-select');
       if (sel) {
         sel.addEventListener('change', function (e) {
           const l = e.target.value;
-          localStorage.setItem('homelog-lang', l);
+          saveLang(l);
           applyLang(l);
         });
       }


### PR DESCRIPTION
  Public-facing surfaces so demo users can discover how to self-host
  and support the project.

  Landing (homelog.dev):
  - New static landing in landing/ (Tailwind CDN, no build step)
  - Bilingual IT/EN via a language dropdown — defaults to the browser language, choice persisted in localStorage
  - Marked work-in-progress

  Docs (docs.homelog.dev):
  - New VitePress site in docs-site/: home + 6 guide pages
  - Bilingual: EN at /, IT at /it/, with a first-visit redirect by browser language; persistent work-in-progress banner; local search

  Donations & discovery:
  - .github/FUNDING.yml enables the GitHub Sponsor button (Ko-fi + Sponsors)
  - In-app: "Self-host on GitHub" links in the demo banner and login box; an "About & Support" card in Settings (version, Star, Donate)
  - Central frontend/src/config/links.js for external URLs
  - README: header links (demo/website/docs) + Ko-fi/Sponsors in Support