### PR TITLE
feat: implement netting of counter-shares in settlement process for a…

### DIFF
--- a/backend/internal/handlers/money_flows_test.go
+++ b/backend/internal/handlers/money_flows_test.go
@@ -517,6 +517,127 @@ func TestSettlement_AmountExceedingOutstanding_Returns400(t *testing.T) {
 	}
 }
 
+// ── 2b-bis. Netting the counter-shares ──────────────────────────────────────
+//
+// The balance between two members is netted, so the "Salda" button offers the
+// *net* figure. The settlement ledger used to apply that net figure FIFO over
+// the outstanding shares in BOTH directions, so a share the recipient owed the
+// payer ate part of the cash: paying the exact net left a residue of twice the
+// counter-share, and the balance never reached zero.
+
+func TestSettlement_NetPayment_ClearsBothDirections(t *testing.T) {
+	f := setupMoneyFixture(t)
+
+	debtID := f.createSplitExpense(t, 200, []uint{f.mBob.ID})                           // bob owes alice 100
+	creditID := f.createSplitExpenseBy(t, f.bobTok, f.mBob.ID, 60, []uint{f.mAlice.ID}) // alice owes bob 30
+
+	if !approx(f.balance(t, f.mAlice.ID, f.mBob.ID), 70) {
+		t.Fatalf("precondition: netted balance should be 70, got %.2f", f.balance(t, f.mAlice.ID, f.mBob.ID))
+	}
+
+	// Bob pays exactly the net balance — nothing may be left owed either way.
+	rec := doJSON(t, f.router, http.MethodPost, "/settlements", f.aliceTok, map[string]any{
+		"property_id": f.prop.ID, "from_member_id": f.mBob.ID, "to_member_id": f.mAlice.ID,
+		"amount": 70.0, "date": "2026-05-03",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("settlement: status %d, body %s", rec.Code, rec.Body.String())
+	}
+
+	if b := f.balance(t, f.mAlice.ID, f.mBob.ID); !approx(b, 0) {
+		t.Errorf("balance after paying the full net = %.2f, want 0", b)
+	}
+	if bob := f.splitFor(t, debtID, f.mBob.ID); !bob.IsSettled {
+		t.Errorf("bob's 100 share must be fully settled, settled_amount = %.2f", bob.SettledAmount)
+	}
+	if alice := f.splitFor(t, creditID, f.mAlice.ID); !alice.IsSettled {
+		t.Errorf("alice's 30 counter-share must be netted away, settled_amount = %.2f", alice.SettledAmount)
+	}
+}
+
+func TestSettlement_PartialPayment_NetsCounterSharesInFull(t *testing.T) {
+	f := setupMoneyFixture(t)
+
+	debtID := f.createSplitExpense(t, 200, []uint{f.mBob.ID})                           // bob owes alice 100
+	creditID := f.createSplitExpenseBy(t, f.bobTok, f.mBob.ID, 60, []uint{f.mAlice.ID}) // alice owes bob 30
+
+	rec := doJSON(t, f.router, http.MethodPost, "/settlements", f.aliceTok, map[string]any{
+		"property_id": f.prop.ID, "from_member_id": f.mBob.ID, "to_member_id": f.mAlice.ID,
+		"amount": 20.0, "date": "2026-05-03",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("settlement: status %d, body %s", rec.Code, rec.Body.String())
+	}
+
+	// 20 in cash + the 30 cancelled out come off bob's share; what is left owed
+	// equals the new balance, so the itemised list and the balance agree.
+	bob := f.splitFor(t, debtID, f.mBob.ID)
+	if !approx(bob.SettledAmount, 50) {
+		t.Errorf("bob.SettledAmount = %.2f, want 50 (20 paid + 30 netted)", bob.SettledAmount)
+	}
+	if bob.IsSettled {
+		t.Error("bob's share is only half covered — it must stay unsettled")
+	}
+	if alice := f.splitFor(t, creditID, f.mAlice.ID); !alice.IsSettled {
+		t.Errorf("alice's counter-share must be netted away, settled_amount = %.2f", alice.SettledAmount)
+	}
+	if b := f.balance(t, f.mAlice.ID, f.mBob.ID); !approx(b, 50) {
+		t.Errorf("balance = %.2f, want 50 (70 net minus the 20 paid)", b)
+	}
+}
+
+// The cap is the net debt, not the gross sum of both directions: bob owes 100
+// but holds a 30 credit, so 100 is more than he owes.
+func TestSettlement_AmountAboveNetButBelowGross_Returns400(t *testing.T) {
+	f := setupMoneyFixture(t)
+
+	f.createSplitExpense(t, 200, []uint{f.mBob.ID})                         // bob owes alice 100
+	f.createSplitExpenseBy(t, f.bobTok, f.mBob.ID, 60, []uint{f.mAlice.ID}) // alice owes bob 30
+
+	rec := doJSON(t, f.router, http.MethodPost, "/settlements", f.aliceTok, map[string]any{
+		"property_id": f.prop.ID, "from_member_id": f.mBob.ID, "to_member_id": f.mAlice.ID,
+		"amount": 100.0, "date": "2026-05-03",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 — 100 exceeds the 70 net owed (body %s)", rec.Code, rec.Body.String())
+	}
+}
+
+// Reversing a settlement must give the netted counter-shares back too.
+func TestSettlement_Delete_ReversesNettedCounterShares(t *testing.T) {
+	f := setupMoneyFixture(t)
+
+	debtID := f.createSplitExpense(t, 200, []uint{f.mBob.ID})
+	creditID := f.createSplitExpenseBy(t, f.bobTok, f.mBob.ID, 60, []uint{f.mAlice.ID})
+
+	rec := doJSON(t, f.router, http.MethodPost, "/settlements", f.aliceTok, map[string]any{
+		"property_id": f.prop.ID, "from_member_id": f.mBob.ID, "to_member_id": f.mAlice.ID,
+		"amount": 70.0, "date": "2026-05-03",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("settlement: status %d, body %s", rec.Code, rec.Body.String())
+	}
+	var s models.Settlement
+	if err := json.Unmarshal(rec.Body.Bytes(), &s); err != nil {
+		t.Fatalf("decode settlement: %v", err)
+	}
+
+	del := doJSON(t, f.router, http.MethodDelete, "/settlements/"+itoa(s.ID), f.aliceTok, nil)
+	if del.Code != http.StatusOK {
+		t.Fatalf("delete settlement: status %d, body %s", del.Code, del.Body.String())
+	}
+
+	if bob := f.splitFor(t, debtID, f.mBob.ID); bob.IsSettled || !approx(bob.SettledAmount, 0) {
+		t.Errorf("bob's share must be fully owed again, settled=%v amount=%.2f", bob.IsSettled, bob.SettledAmount)
+	}
+	if alice := f.splitFor(t, creditID, f.mAlice.ID); alice.IsSettled || !approx(alice.SettledAmount, 0) {
+		t.Errorf("alice's counter-share must come back, settled=%v amount=%.2f", alice.IsSettled, alice.SettledAmount)
+	}
+	if b := f.balance(t, f.mAlice.ID, f.mBob.ID); !approx(b, 70) {
+		t.Errorf("balance = %.2f, want the original 70 net", b)
+	}
+}
+
 // ── 2c. Long-term debts ─────────────────────────────────────────────────────
 //
 // A mortgage down payment is not an ordinary expense: netted into the running

--- a/backend/internal/handlers/settlement.go
+++ b/backend/internal/handlers/settlement.go
@@ -142,18 +142,28 @@ func (h *SettlementHandler) Create(c *gin.Context) {
 		return
 	}
 
-	// Fetch outstanding splits between the pair, oldest expense first — the
-	// payment is applied as a ledger, oldest debt paid down before newer ones.
-	query := h.db.
-		Joins("JOIN expenses ON expenses.id = expense_splits.expense_id").
-		Where("expense_splits.is_settled = ?", false).
-		Where("expenses.property_id = ?", req.PropertyID).
-		Where("expenses.deleted_at IS NULL")
+	// Outstanding shares between the pair, oldest expense first — the payment
+	// is applied as a ledger, oldest debt paid down before newer ones.
+	outstanding := func() *gorm.DB {
+		return h.db.
+			Joins("JOIN expenses ON expenses.id = expense_splits.expense_id").
+			Where("expense_splits.is_settled = ?", false).
+			Where("expenses.property_id = ?", req.PropertyID).
+			Where("expenses.deleted_at IS NULL")
+	}
+
+	// debtQuery: shares the payer still owes the recipient — what this payment
+	// actually repays. Only ever this direction: paying Alice must not clear
+	// what Alice owes you.
+	debtQuery := outstanding().
+		Where("expenses.paid_by_member_id = ? AND expense_splits.member_id = ?", req.ToMemberID, req.FromMemberID)
+
+	// credits: shares the recipient owes the payer. No money moves for them —
+	// they cancel against the debts above (see the netting below). Empty for a
+	// payment aimed at a single long-term debt, which is never netted.
+	var credits []models.ExpenseSplit
 
 	if req.TargetExpenseID != nil {
-		// Aimed at one long-term debt: only that expense's share, and only in
-		// the direction the payer actually owes — paying Alice must not clear
-		// what Alice owes you.
 		var target models.Expense
 		if err := h.db.First(&target, *req.TargetExpenseID).Error; err != nil {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Debito non trovato"})
@@ -163,30 +173,43 @@ func (h *SettlementHandler) Create(c *gin.Context) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Questa spesa non è un debito a lungo termine"})
 			return
 		}
-		query = query.
-			Where("expenses.id = ?", target.ID).
-			Where("expenses.paid_by_member_id = ? AND expense_splits.member_id = ?", req.ToMemberID, req.FromMemberID)
+		debtQuery = debtQuery.Where("expenses.id = ?", target.ID)
 	} else {
 		// Ordinary balance: long-term debts are repaid explicitly, never swept
 		// up by a generic settlement.
-		query = query.
+		debtQuery = debtQuery.Where("expenses.is_long_term_debt = ?", false)
+
+		if err := outstanding().
 			Where("expenses.is_long_term_debt = ?", false).
-			Where("(expenses.paid_by_member_id = ? AND expense_splits.member_id = ?) OR (expenses.paid_by_member_id = ? AND expense_splits.member_id = ?)",
-				req.ToMemberID, req.FromMemberID, req.FromMemberID, req.ToMemberID)
+			Where("expenses.paid_by_member_id = ? AND expense_splits.member_id = ?", req.FromMemberID, req.ToMemberID).
+			Order("expenses.date ASC").
+			Find(&credits).Error; err != nil {
+			log.Printf("ERROR finding counter-shares to net: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to find expense splits"})
+			return
+		}
 	}
 
 	var splits []models.ExpenseSplit
-	if err := query.Order("expenses.date ASC").Find(&splits).Error; err != nil {
+	if err := debtQuery.Order("expenses.date ASC").Find(&splits).Error; err != nil {
 		log.Printf("ERROR finding expense splits to settle: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to find expense splits"})
 		return
 	}
 
-	var totalOwed float64
+	var owedByPayer, owedToPayer float64
 	for _, s := range splits {
-		totalOwed += remainingOwed(s)
+		owedByPayer += remainingOwed(s)
 	}
-	if req.Amount > totalOwed+settlementEpsilon {
+	for _, s := range credits {
+		owedToPayer += remainingOwed(s)
+	}
+
+	// The balance between two members is netted (see CalculateBalance), so the
+	// most that can legitimately change hands is the *net* debt. Validating
+	// against the gross total would accept a payment larger than what is owed.
+	netOwed := owedByPayer - owedToPayer
+	if req.Amount > netOwed+settlementEpsilon {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "L'importo supera il debito residuo tra questi membri"})
 		return
 	}
@@ -214,12 +237,35 @@ func (h *SettlementHandler) Create(c *gin.Context) {
 	log.Printf("Settlement created - ID: %d, From: %d, To: %d, Amount: %.2f",
 		settlement.ID, req.FromMemberID, req.ToMemberID, req.Amount)
 
+	now := time.Now()
+
+	// Cancel the counter-shares first. The recipient owes these back to the
+	// payer, so no cash covers them — they are offset against the debts this
+	// settlement repays, exactly as the netted balance already presents them.
+	// Netting them in full always fits (owedByPayer >= req.Amount + owedToPayer)
+	// and leaves the outstanding shares equal to the balance after the payment.
+	netted := 0.0
+	for i := range credits {
+		owed := remainingOwed(credits[i])
+		if owed <= settlementEpsilon {
+			continue
+		}
+		if err := applyAllocation(tx, settlement.ID, credits[i], owed, allocationKindFunding, now); err != nil {
+			tx.Rollback()
+			log.Printf("ERROR netting counter-share split %d: %v", credits[i].ID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to allocate settlement"})
+			return
+		}
+		netted += owed
+	}
+
 	// Apply the payment against the outstanding splits, oldest first. Each
 	// split touched gets a SettlementAllocation recording exactly how much of
 	// this settlement covered it; a split not fully covered stays unsettled
 	// with a reduced remaining balance instead of being force-marked settled.
-	now := time.Now()
-	remaining := req.Amount
+	// The cash is joined by whatever the counter-shares cancelled out.
+	remaining := req.Amount + netted
+	toAllocate := remaining
 	touched := 0
 	for i := range splits {
 		if remaining <= settlementEpsilon {
@@ -242,7 +288,8 @@ func (h *SettlementHandler) Create(c *gin.Context) {
 		touched++
 	}
 
-	log.Printf("✅ SETTLEMENT: Allocated %.2f across %d splits", req.Amount-remaining, touched)
+	log.Printf("✅ SETTLEMENT: Allocated %.2f across %d splits (%.2f cash + %.2f netted from counter-shares)",
+		toAllocate-remaining, touched, req.Amount, netted)
 
 	if err := tx.Commit().Error; err != nil {
 		log.Printf("ERROR committing transaction: %v", err)


### PR DESCRIPTION
This pull request introduces comprehensive improvements to the settlement logic for netting balances between two members. Settlements now properly net out counter-shares (amounts the recipient owes the payer), ensuring the net balance is always correct and that settlements cannot overpay the net debt. The changes also include thorough tests to verify the new behavior and ensure reversals restore all balances correctly.

**Settlement netting logic improvements:**

* The settlement logic now explicitly nets out counter-shares: before applying a payment, any outstanding credits the recipient owes the payer are cancelled out, so only the net debt is settled with cash. This ensures that the balance reaches zero when the net is paid, and prevents overpayment beyond the net debt. [[1]](diffhunk://#diff-09000d03004baf0f5e1c92e44a1c7fe66b72b3f086c4295d5e80fa7c0edd67cdL145-R166) [[2]](diffhunk://#diff-09000d03004baf0f5e1c92e44a1c7fe66b72b3f086c4295d5e80fa7c0edd67cdL166-R212) [[3]](diffhunk://#diff-09000d03004baf0f5e1c92e44a1c7fe66b72b3f086c4295d5e80fa7c0edd67cdR240-R268)

* The validation for settlement amounts now caps the payment at the net amount owed (debts minus credits), rather than the gross total of both directions. This prevents users from overpaying when there are counter-shares.

**Testing and correctness:**

* Added new tests in `money_flows_test.go` to verify that settlements clear both directions, partial payments net counter-shares in full, overpayments above the net are rejected, and reversing a settlement restores both debts and credits.

**Logging and traceability:**

* Improved logging to clearly show how much was allocated to splits as cash and how much was netted from counter-shares, aiding in debugging and auditability.